### PR TITLE
Update TempRemount function to handle both read-only and read-write mounted volumes

### DIFF
--- a/internal/ebutil/remount.go
+++ b/internal/ebutil/remount.go
@@ -84,13 +84,11 @@ func tempRemount(m mounter, logf log.Func, base string, ignorePrefixes ...string
 
 outer:
 	for _, mountInfo := range mountInfos {
-		// Check for both ro and rw mounts
-		if _, ok := mountInfo.Options["ro"]; !ok {
-			if _, ok := mountInfo.Options["rw"]; !ok {
-				logf(log.LevelDebug, "skip mount %s", mountInfo.MountPoint)
-				continue
-			}
-		}
+		// TODO: do this for all mounts
+		// if _, ok := mountInfo.Options["ro"]; !ok {
+		// 	logf(log.LevelDebug, "skip rw mount %s", mountInfo.MountPoint)
+		// 	continue
+		// }
 
 		for _, prefix := range ignorePrefixes {
 			if strings.HasPrefix(mountInfo.MountPoint, prefix) {
@@ -150,13 +148,7 @@ func remount(m mounter, src, dest, libDir string, libsSymlinks map[string][]stri
 		}
 	}
 
-	// Preserve the ro and rw properties
-	flags := uintptr(syscall.MS_BIND)
-	if _, ok := m.Stat(src).(*os.FileInfo).Mode().Perm() & 0222; !ok {
-		flags |= syscall.MS_RDONLY
-	}
-
-	if err := m.Mount(src, dest, "bind", flags, ""); err != nil {
+	if err := m.Mount(src, dest, "bind", syscall.MS_BIND, ""); err != nil {
 		return fmt.Errorf("bind mount %s => %s: %w", src, dest, err)
 	}
 

--- a/internal/ebutil/remount.go
+++ b/internal/ebutil/remount.go
@@ -99,6 +99,10 @@ outer:
 
 		src := mountInfo.MountPoint
 		dest := filepath.Join(base, src)
+		if src == "/" {
+			logf(log.LevelDebug, "skip root mount %s", src)
+			continue
+		}
 		logf(log.LevelDebug, "temp remount %s", src)
 		if err := remount(m, src, dest, libDir, libsSymlinks); err != nil {
 			return restore, fmt.Errorf("temp remount: %w", err)

--- a/internal/ebutil/remount_internal_test.go
+++ b/internal/ebutil/remount_internal_test.go
@@ -637,7 +637,7 @@ func Test_tempRemount(t *testing.T) {
 		require.ErrorContains(t, err, assert.AnError.Error())
 	})
 
-	t.Run("ReadWriteMounts", func(t *testing.T) {
+	t.Run("OKReadWrite", func(t *testing.T) {
 		t.Parallel()
 
 		ctrl := gomock.NewController(t)
@@ -656,6 +656,232 @@ func Test_tempRemount(t *testing.T) {
 		mm.EXPECT().MkdirAll("/var/lib/modules", os.FileMode(0o750)).Times(1).Return(nil)
 		mm.EXPECT().Mount("/.test/var/lib/modules", "/var/lib/modules", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
 		mm.EXPECT().Unmount("/.test/var/lib/modules", 0).Times(1).Return(nil)
+
+		remount, err := tempRemount(mm, fakeLog(t), "/.test")
+		require.NoError(t, err)
+		err = remount()
+		require.NoError(t, err)
+		// sync.Once should handle multiple remount calls
+		_ = remount()
+	})
+
+	t.Run("OKFileReadWrite", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mm := NewMockmounter(ctrl)
+		mounts := fakeMounts("/home", "/usr/bin/utility:rw", "/proc", "/sys")
+
+		mm.EXPECT().GetMounts().Return(mounts, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().ReadDir("/usr/lib64").Return(nil, os.ErrNotExist)
+		mm.EXPECT().Stat("/usr/bin/utility").Return(&fakeFileInfo{name: "modules", isDir: false}, nil)
+		mm.EXPECT().MkdirAll("/.test/usr/bin", os.FileMode(0o750)).Times(1).Return(nil)
+		mm.EXPECT().OpenFile("/.test/usr/bin/utility", os.O_CREATE, os.FileMode(0o640)).Times(1).Return(new(os.File), nil)
+		mm.EXPECT().Mount("/usr/bin/utility", "/.test/usr/bin/utility", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
+		mm.EXPECT().Unmount("/usr/bin/utility", 0).Times(1).Return(nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().Stat("/.test/usr/bin/utility").Return(&fakeFileInfo{name: "modules", isDir: false}, nil)
+		mm.EXPECT().MkdirAll("/usr/bin", os.FileMode(0o750)).Times(1).Return(nil)
+		mm.EXPECT().OpenFile("/usr/bin/utility", os.O_CREATE, os.FileMode(0o640)).Times(1).Return(new(os.File), nil)
+		mm.EXPECT().Mount("/.test/usr/bin/utility", "/usr/bin/utility", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
+		mm.EXPECT().Unmount("/.test/usr/bin/utility", 0).Times(1).Return(nil)
+
+		remount, err := tempRemount(mm, fakeLog(t), "/.test")
+		require.NoError(t, err)
+		err = remount()
+		require.NoError(t, err)
+		// sync.Once should handle multiple remount calls
+		_ = remount()
+	})
+
+	t.Run("OKLibReadWrite", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mm := NewMockmounter(ctrl)
+		mounts := fakeMounts("/home", "/usr/lib64/lib.so.1:rw", "/proc", "/sys")
+
+		mm.EXPECT().GetMounts().Return(mounts, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().ReadDir("/usr/lib64").Return([]os.DirEntry{
+			&fakeDirEntry{
+				name: "lib.so",
+				mode: os.ModeSymlink,
+			},
+			&fakeDirEntry{
+				name: "lib.so.1",
+			},
+			&fakeDirEntry{
+				name: "lib-other.so",
+				mode: os.ModeSymlink,
+			},
+			&fakeDirEntry{
+				name: "lib-other.so.1",
+			},
+			&fakeDirEntry{
+				name:  "something.d",
+				isDir: true,
+				mode:  os.ModeDir,
+			},
+		}, nil)
+		mm.EXPECT().EvalSymlinks("/usr/lib64/lib.so").Return("/usr/lib64/lib.so.1", nil)
+		mm.EXPECT().EvalSymlinks("/usr/lib64/lib-other.so").Return("/usr/lib64/lib-other.so.1", nil)
+		mm.EXPECT().Stat("/usr/lib64/lib.so.1").Return(&fakeFileInfo{name: "lib.so.1", isDir: false}, nil)
+		mm.EXPECT().MkdirAll("/.test/usr/lib64", os.FileMode(0o750)).Times(1).Return(nil)
+		mm.EXPECT().OpenFile("/.test/usr/lib64/lib.so.1", os.O_CREATE, os.FileMode(0o640)).Times(1).Return(new(os.File), nil)
+		mm.EXPECT().Rename("/usr/lib64/lib.so", "/.test/usr/lib64/lib.so").Return(nil)
+		mm.EXPECT().Mount("/usr/lib64/lib.so.1", "/.test/usr/lib64/lib.so.1", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
+		mm.EXPECT().Unmount("/usr/lib64/lib.so.1", 0).Times(1).Return(nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().Stat("/.test/usr/lib64/lib.so.1").Return(&fakeFileInfo{name: "lib.so.1", isDir: false}, nil)
+		mm.EXPECT().MkdirAll("/usr/lib64", os.FileMode(0o750)).Times(1).Return(nil)
+		mm.EXPECT().OpenFile("/usr/lib64/lib.so.1", os.O_CREATE, os.FileMode(0o640)).Times(1).Return(new(os.File), nil)
+		mm.EXPECT().Rename("/.test/usr/lib64/lib.so", "/usr/lib64/lib.so").Return(nil)
+		mm.EXPECT().Mount("/.test/usr/lib64/lib.so.1", "/usr/lib64/lib.so.1", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
+		mm.EXPECT().Unmount("/.test/usr/lib64/lib.so.1", 0).Times(1).Return(nil)
+
+		remount, err := tempRemount(mm, fakeLog(t), "/.test")
+		require.NoError(t, err)
+		err = remount()
+		require.NoError(t, err)
+		// sync.Once should handle multiple remount calls
+		_ = remount()
+	})
+
+	t.Run("OKLibDebianReadWrite", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mm := NewMockmounter(ctrl)
+		mounts := fakeMounts("/home", "/usr/lib64/lib.so.1:rw", "/proc", "/sys")
+
+		mm.EXPECT().GetMounts().Return(mounts, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().ReadDir("/usr/lib64").Return([]os.DirEntry{
+			&fakeDirEntry{
+				name: "lib.so",
+				mode: os.ModeSymlink,
+			},
+			&fakeDirEntry{
+				name: "lib.so.1",
+			},
+			&fakeDirEntry{
+				name: "lib-other.so",
+				mode: os.ModeSymlink,
+			},
+			&fakeDirEntry{
+				name: "lib-other.so.1",
+			},
+			&fakeDirEntry{
+				name:  "something.d",
+				isDir: true,
+				mode:  os.ModeDir,
+			},
+		}, nil)
+		mm.EXPECT().EvalSymlinks("/usr/lib64/lib.so").Return("lib.so.1", nil)
+		mm.EXPECT().EvalSymlinks("/usr/lib64/lib-other.so").Return("lib-other.so.1", nil)
+		mm.EXPECT().Stat("/usr/lib64/lib.so.1").Return(&fakeFileInfo{name: "lib.so.1", isDir: false}, nil)
+		mm.EXPECT().MkdirAll("/.test/usr/lib64", os.FileMode(0o750)).Times(1).Return(nil)
+		mm.EXPECT().OpenFile("/.test/usr/lib64/lib.so.1", os.O_CREATE, os.FileMode(0o640)).Times(1).Return(new(os.File), nil)
+		mm.EXPECT().Rename("/usr/lib64/lib.so", "/.test/usr/lib64/lib.so").Return(nil)
+		mm.EXPECT().Mount("/usr/lib64/lib.so.1", "/.test/usr/lib64/lib.so.1", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
+		mm.EXPECT().Unmount("/usr/lib64/lib.so.1", 0).Times(1).Return(nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, nil)
+		mm.EXPECT().Stat("/.test/usr/lib64/lib.so.1").Return(&fakeFileInfo{name: "lib.so.1", isDir: false}, nil)
+		mm.EXPECT().MkdirAll(expectedLibMultiarchDir[runtime.GOARCH], os.FileMode(0o750)).Times(1).Return(nil)
+		mm.EXPECT().OpenFile(expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so.1", os.O_CREATE, os.FileMode(0o640)).Times(1).Return(new(os.File), nil)
+		mm.EXPECT().Rename("/.test/usr/lib64/lib.so", expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so").Return(nil)
+		mm.EXPECT().Mount("/.test/usr/lib64/lib.so.1", expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so.1", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
+		mm.EXPECT().Unmount("/.test/usr/lib64/lib.so.1", 0).Times(1).Return(nil)
+
+		remount, err := tempRemount(mm, fakeLog(t), "/.test")
+		require.NoError(t, err)
+		err = remount()
+		require.NoError(t, err)
+		// sync.Once should handle multiple remount calls
+		_ = remount()
+	})
+
+	t.Run("OKLibFromDebianToNotDebianReadWrite", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mm := NewMockmounter(ctrl)
+		mounts := fakeMounts("/home", expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so.1:rw", "/proc", "/sys")
+
+		mm.EXPECT().GetMounts().Return(mounts, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, nil)
+		mm.EXPECT().ReadDir(expectedLibMultiarchDir[runtime.GOARCH]).Return([]os.DirEntry{
+			&fakeDirEntry{
+				name: "lib.so",
+				mode: os.ModeSymlink,
+			},
+			&fakeDirEntry{
+				name: "lib.so.1",
+			},
+			&fakeDirEntry{
+				name: "lib-other.so",
+				mode: os.ModeSymlink,
+			},
+			&fakeDirEntry{
+				name: "lib-other.so.1",
+			},
+			&fakeDirEntry{
+				name:  "something.d",
+				isDir: true,
+				mode:  os.ModeDir,
+			},
+		}, nil)
+		mm.EXPECT().EvalSymlinks(expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so").Return(expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so.1", nil)
+		mm.EXPECT().EvalSymlinks(expectedLibMultiarchDir[runtime.GOARCH]+"/lib-other.so").Return(expectedLibMultiarchDir[runtime.GOARCH]+"/usr/lib64/lib-other.so.1", nil)
+		mm.EXPECT().Stat(expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so.1").Return(&fakeFileInfo{name: "lib.so.1", isDir: false}, nil)
+		mm.EXPECT().MkdirAll("/.test"+expectedLibMultiarchDir[runtime.GOARCH], os.FileMode(0o750)).Times(1).Return(nil)
+		mm.EXPECT().OpenFile("/.test"+expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so.1", os.O_CREATE, os.FileMode(0o640)).Times(1).Return(new(os.File), nil)
+		mm.EXPECT().Rename(expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so", "/.test"+expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so").Return(nil)
+		mm.EXPECT().Mount(expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so.1", "/.test"+expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so.1", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
+		mm.EXPECT().Unmount(expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so.1", 0).Times(1).Return(nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().Stat("/.test"+expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so.1").Return(&fakeFileInfo{name: "lib.so.1", isDir: false}, nil)
+		mm.EXPECT().MkdirAll("/usr/lib64", os.FileMode(0o750)).Times(1).Return(nil)
+		mm.EXPECT().OpenFile("/usr/lib64/lib.so.1", os.O_CREATE, os.FileMode(0o640)).Times(1).Return(new(os.File), nil)
+		mm.EXPECT().Rename("/.test"+expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so", "/usr/lib64/lib.so").Return(nil)
+		mm.EXPECT().Mount("/.test"+expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so.1", "/usr/lib64/lib.so.1", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
+		mm.EXPECT().Unmount("/.test"+expectedLibMultiarchDir[runtime.GOARCH]+"/lib.so.1", 0).Times(1).Return(nil)
+
+		remount, err := tempRemount(mm, fakeLog(t), "/.test")
+		require.NoError(t, err)
+		err = remount()
+		require.NoError(t, err)
+		// sync.Once should handle multiple remount calls
+		_ = remount()
+	})
+
+	t.Run("OKLibNoSymlinkReadWrite", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mm := NewMockmounter(ctrl)
+		mounts := fakeMounts("/home", "/usr/lib64/lib.so.1:rw", "/proc", "/sys")
+
+		mm.EXPECT().GetMounts().Return(mounts, nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().ReadDir("/usr/lib64").Return([]os.DirEntry{
+			&fakeDirEntry{
+				name: "lib.so.1",
+			},
+		}, nil)
+		mm.EXPECT().Stat("/usr/lib64/lib.so.1").Return(&fakeFileInfo{name: "lib.so.1", isDir: false}, nil)
+		mm.EXPECT().MkdirAll("/.test/usr/lib64", os.FileMode(0o750)).Times(1).Return(nil)
+		mm.EXPECT().OpenFile("/.test/usr/lib64/lib.so.1", os.O_CREATE, os.FileMode(0o640)).Times(1).Return(new(os.File), nil)
+		mm.EXPECT().Mount("/usr/lib64/lib.so.1", "/.test/usr/lib64/lib.so.1", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
+		mm.EXPECT().Unmount("/usr/lib64/lib.so.1", 0).Times(1).Return(nil)
+		mm.EXPECT().Stat("/etc/debian_version").Return(nil, os.ErrNotExist)
+		mm.EXPECT().Stat("/.test/usr/lib64/lib.so.1").Return(&fakeFileInfo{name: "lib.so.1", isDir: false}, nil)
+		mm.EXPECT().MkdirAll("/usr/lib64", os.FileMode(0o750)).Times(1).Return(nil)
+		mm.EXPECT().OpenFile("/usr/lib64/lib.so.1", os.O_CREATE, os.FileMode(0o640)).Times(1).Return(new(os.File), nil)
+		mm.EXPECT().Mount("/.test/usr/lib64/lib.so.1", "/usr/lib64/lib.so.1", "bind", uintptr(syscall.MS_BIND), "").Times(1).Return(nil)
+		mm.EXPECT().Unmount("/.test/usr/lib64/lib.so.1", 0).Times(1).Return(nil)
 
 		remount, err := tempRemount(mm, fakeLog(t), "/.test")
 		require.NoError(t, err)


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/alodex/envbuilder/pull/2?shareId=75b5e441-b5c7-4e91-8124-cab74138c77e).